### PR TITLE
Make "d" in "appId" lowercase

### DIFF
--- a/help/developing/archetype/overview.md
+++ b/help/developing/archetype/overview.md
@@ -104,7 +104,7 @@ Name                        | Default | Description
 `artifactId`                |         | Base Maven ArtifactId
 `version`                   |         | Version
 `package`                   |         | Java Source Package
-`appID`                     |         | Application ID used for component, configuration, and content folders and css IDs
+`appId`                     |         | Application ID used for component, configuration, and content folders and css IDs
 `appTitle`                  |         | Application title used for the website title and components groups
 `aemVersion`                | 6.5.0   | Target AEM version
 `sdkVersion`                |         | 


### PR DESCRIPTION
Per [the archetype][1], the `d` in `appId` should be lowercase.

[1]: https://github.com/adobe/aem-project-archetype/tree/master