### PR TITLE
Add info about Page component to context-aware-configs.md

### DIFF
--- a/help/developing/context-aware-configs.md
+++ b/help/developing/context-aware-configs.md
@@ -22,6 +22,7 @@ A number of Core Components features leverage context-aware configurations. All 
 
 Individual configurations depend on the specific component or feature. Features of the Core Components that use context-aware configurations are:
 
+* [The Page Component](https://github.com/adobe/aem-core-wcm-components/tree/main/content/src/content/jcr_root/apps/core/wcm/components/page/v3/page#loading-of-context-aware-cssjs) relies on Context Aware Configuration when rendering `link`, `script` and `meta` tags
 * [PDF Viewer Component](https://github.com/adobe/aem-core-wcm-components/tree/master/content/src/content/jcr_root/apps/core/wcm/components/pdfviewer/v1/pdfviewer#context-aware-config)
 * [Adobe Client Data Layer](/help/developing/data-layer/overview.md#installation-activation)
 * [AMP Support](https://github.com/adobe/aem-core-wcm-components/tree/master/extensions/amp)


### PR DESCRIPTION
Add a reference to the Page component from AEM Core Components using the Context Aware Configuration for `HtmlPageItemsConfig` to render tags.